### PR TITLE
Disable & Enable shard reallocation

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,41 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("add called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(addCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,41 +1,46 @@
-// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
-//
-
 package cmd
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/dtan4/esnctl/es"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	Use:           "add",
+	Short:         "Add Elasticsearch node",
+	RunE:          doAdd,
+}
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Work your own magic here
-		fmt.Println("add called")
-	},
+func doAdd(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("cluster URL must be specified")
+	}
+	clusterURL := args[0]
+
+	client, err := es.New(clusterURL)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Elasitcsearch API client")
+	}
+
+	if err := client.DisableReallocation(); err != nil {
+		return errors.Wrap(err, "failed to disable reallocation")
+	}
+	defer client.EnableReallocation()
+
+	fmt.Println("TODO: Add node here")
+
+	time.Sleep(10 * time.Second)
+
+	return nil
 }
 
 func init() {
 	RootCmd.AddCommand(addCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
 }

--- a/es/client.go
+++ b/es/client.go
@@ -2,5 +2,6 @@ package es
 
 // Client represents innterface of Elasticsearch API client
 type Client interface {
+	EnableReallocation() error
 	ListNodes() ([]string, error)
 }

--- a/es/client.go
+++ b/es/client.go
@@ -2,6 +2,7 @@ package es
 
 // Client represents innterface of Elasticsearch API client
 type Client interface {
+	DisableReallocation() error
 	EnableReallocation() error
 	ListNodes() ([]string, error)
 }

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -53,6 +53,27 @@ func NewClient(clusterURL string) (*Client, error) {
 	}, nil
 }
 
+// DisableReallocation enables shard reallocation
+// Modifies cluster.routing.allocation.enable to "none"
+// https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
+func (c *Client) DisableReallocation() error {
+	httpClient := &http.Client{}
+	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+
+	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"none"}}`))
+	if err != nil {
+		return errors.Wrap(err, "failed to make DisableReallocation request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute DisableReallocation request")
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
 // EnableReallocation enables shard reallocation
 // Modifies cluster.routing.allocation.enable to "all"
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -2,7 +2,10 @@ package v1
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
+	"path"
+	"strings"
 
 	"github.com/pkg/errors"
 	"gopkg.in/olivere/elastic.v2"
@@ -48,6 +51,27 @@ func NewClient(clusterURL string) (*Client, error) {
 		client:          client,
 		clusterEndpoint: clusterEndpoint,
 	}, nil
+}
+
+// EnableReallocation enables shard reallocation
+// Modifies cluster.routing.allocation.enable to "all"
+// https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
+func (c *Client) EnableReallocation() error {
+	httpClient := &http.Client{}
+	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+
+	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"all"}}`))
+	if err != nil {
+		return errors.Wrap(err, "failed to make EnableReallocation request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute EnableReallocation request")
+	}
+	defer resp.Body.Close()
+
+	return nil
 }
 
 // ListNodes returns the list of node names

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -58,12 +57,13 @@ func NewClient(clusterURL string) (*Client, error) {
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) DisableReallocation() error {
 	httpClient := &http.Client{}
-	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"none"}}`))
 	if err != nil {
 		return errors.Wrap(err, "failed to make DisableReallocation request")
 	}
+	defer req.Body.Close()
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -79,12 +79,13 @@ func (c *Client) DisableReallocation() error {
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) EnableReallocation() error {
 	httpClient := &http.Client{}
-	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"all"}}`))
 	if err != nil {
 		return errors.Wrap(err, "failed to make EnableReallocation request")
 	}
+	defer req.Body.Close()
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -71,6 +72,15 @@ func (c *Client) DisableReallocation() error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.Errorf("failed to execute DisableReallocation request. code: %d, body: %s", resp.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -92,6 +102,15 @@ func (c *Client) EnableReallocation() error {
 		return errors.Wrap(err, "failed to execute EnableReallocation request")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.Errorf("failed to execute DisableReallocation request. code: %d, body: %s", resp.StatusCode, body)
+	}
 
 	return nil
 }

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -54,6 +54,27 @@ func NewClient(clusterURL string) (*Client, error) {
 }
 
 // EnableReallocation enables shard reallocation
+// Modifies cluster.routing.allocation.enable to "none"
+// https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
+func (c *Client) DisableReallocation() error {
+	httpClient := &http.Client{}
+	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+
+	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"none"}}`))
+	if err != nil {
+		return errors.Wrap(err, "failed to make DisableReallocation request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute DisableReallocation request")
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// EnableReallocation enables shard reallocation
 // Modifies cluster.routing.allocation.enable to "all"
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) EnableReallocation() error {

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -71,6 +72,15 @@ func (c *Client) DisableReallocation() error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.Errorf("failed to execute DisableReallocation request. code: %d, body: %s", resp.StatusCode, body)
+	}
+
 	return nil
 }
 
@@ -92,6 +102,15 @@ func (c *Client) EnableReallocation() error {
 		return errors.Wrap(err, "failed to execute EnableReallocation request")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.Errorf("failed to execute DisableReallocation request. code: %d, body: %s", resp.StatusCode, body)
+	}
 
 	return nil
 }

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -53,17 +52,18 @@ func NewClient(clusterURL string) (*Client, error) {
 	}, nil
 }
 
-// EnableReallocation enables shard reallocation
+// DisableReallocation enables shard reallocation
 // Modifies cluster.routing.allocation.enable to "none"
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) DisableReallocation() error {
 	httpClient := &http.Client{}
-	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"none"}}`))
 	if err != nil {
 		return errors.Wrap(err, "failed to make DisableReallocation request")
 	}
+	defer req.Body.Close()
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -79,12 +79,13 @@ func (c *Client) DisableReallocation() error {
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) EnableReallocation() error {
 	httpClient := &http.Client{}
-	endpoint := path.Join(c.clusterEndpoint, "_cluster", "settings")
+	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"all"}}`))
 	if err != nil {
 		return errors.Wrap(err, "failed to make EnableReallocation request")
 	}
+	defer req.Body.Close()
 
 	resp, err := httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## WHY

Adding nodes requires the steps below:

- Disable shard reallocation
- Add node
- Enable shard reallocation

https://www.elastic.co/guide/en/elasticsearch/reference/1.4/cluster-nodes-shutdown.html#_rolling_restart_of_nodes_full_cluster_restart

> Disable shard reallocation (optional). This is done to allow for a faster startup after cluster shutdown. If this step is not performed, the nodes will immediately start trying to replicate shards to each other on startup and will spend a lot of time on wasted I/O. With shard reallocation disabled, the nodes will join the cluster with their indices intact, without attempting to rebalance. After startup is complete, reallocation will be turned back on.

## WHAT

Implement disabling & enabling shard reallocation features