### PR TITLE
Remove Elasticsearch node

### DIFF
--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,41 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// removeCmd represents the remove command
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("remove called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(removeCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// removeCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// removeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/es/client.go
+++ b/es/client.go
@@ -6,5 +6,6 @@ type Client interface {
 	EnableReallocation() error
 	ExcludeNodeFromAllocation(nodeName string) error
 	ListNodes() ([]string, error)
+	ListShardsOnNode(nodeName string) ([]string, error)
 	Shutdown(nodeName string) error
 }

--- a/es/client.go
+++ b/es/client.go
@@ -4,5 +4,6 @@ package es
 type Client interface {
 	DisableReallocation() error
 	EnableReallocation() error
+	ExcludeNodeFromAllocation(nodeName string) error
 	ListNodes() ([]string, error)
 }

--- a/es/client.go
+++ b/es/client.go
@@ -6,4 +6,5 @@ type Client interface {
 	EnableReallocation() error
 	ExcludeNodeFromAllocation(nodeName string) error
 	ListNodes() ([]string, error)
+	Shutdown(nodeName string) error
 }

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -161,3 +161,31 @@ func (c *Client) ListNodes() ([]string, error) {
 
 	return nodes, nil
 }
+
+// Shutdown shutdowns the given node
+func (c *Client) Shutdown(nodeName string) error {
+	httpClient := &http.Client{}
+	endpoint := c.clusterEndpoint + "/_cluster/nodes/" + nodeName + "/_shutdown"
+
+	req, err := http.NewRequest("POST", endpoint, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to make Shutdown request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute Shutdown request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read response body")
+		}
+
+		return errors.Errorf("failed to execute Shutdown request. code: %d, body: %s", resp.StatusCode, body)
+	}
+
+	return nil
+}

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -162,6 +162,44 @@ func (c *Client) ListNodes() ([]string, error) {
 	return nodes, nil
 }
 
+// ListShards returns the list of shards on the given node
+func (c *Client) ListShardsOnNode(nodeName string) ([]string, error) {
+	httpClient := &http.Client{}
+	endpoint := c.clusterEndpoint + "/_cat/shards/"
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return []string{}, errors.Wrap(err, "failed to make cat-shards request")
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return []string{}, errors.Wrap(err, "failed to execute Shutdown request")
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []string{}, errors.Wrap(err, "failed to read response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return []string{}, errors.Errorf("failed to execute Shutdown request. code: %d, body: %s", resp.StatusCode, body)
+	}
+
+	lines := strings.Split(string(body), "\n")
+
+	shardsOnNode := []string{}
+
+	for _, line := range lines {
+		if strings.HasSuffix(line, nodeName) {
+			shardsOnNode = append(shardsOnNode, line)
+		}
+	}
+
+	return shardsOnNode, nil
+}
+
 // Shutdown shutdowns the given node
 func (c *Client) Shutdown(nodeName string) error {
 	httpClient := &http.Client{}

--- a/es/v1/client_test.go
+++ b/es/v1/client_test.go
@@ -55,6 +55,36 @@ func TestExcludeNodeFromAllocation(t *testing.T) {
 	}
 }
 
+func TestListShardsOnNode(t *testing.T) {
+	defer gock.Off()
+
+	client := &Client{
+		client:          nil,
+		clusterEndpoint: testClusterEndpoint,
+	}
+
+	gock.New(testClusterEndpoint).Get("/_cat/shards").Reply(200).BodyString(`wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal
+wiki1 1 p STARTED 3013 29.6mb 192.168.56.30 Frankie Raye
+wiki1 2 p STARTED 3973 38.1mb 192.168.56.20 Commander Kraken`)
+
+	nodeName := "ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	shards, err := client.ListShardsOnNode(nodeName)
+	if err != nil {
+		t.Errorf("error should not be raised: %s", err)
+	}
+
+	if len(shards) != 1 {
+		t.Errorf("number of shards does not match. expected: 1, got: %d", len(shards))
+	}
+
+	expected := "wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	if shards[0] != expected {
+		t.Errorf("shard does not match. expected: %q, got: %q", expected, shards[0])
+	}
+}
+
 func TestShutdown(t *testing.T) {
 	defer gock.Off()
 

--- a/es/v1/client_test.go
+++ b/es/v1/client_test.go
@@ -37,3 +37,20 @@ func TestEnableReallocation(t *testing.T) {
 		t.Errorf("error should not be raised: %s", err)
 	}
 }
+
+func TestExcludeNodeFromAllocation(t *testing.T) {
+	defer gock.Off()
+
+	client := &Client{
+		client:          nil,
+		clusterEndpoint: testClusterEndpoint,
+	}
+
+	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.exclude._name":"ip-10-0-1-23.ap-northeast-1.compute.internal"}}`).Reply(200)
+
+	nodeName := "ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	if err := client.ExcludeNodeFromAllocation(nodeName); err != nil {
+		t.Errorf("error should not be raised: %s", err)
+	}
+}

--- a/es/v1/client_test.go
+++ b/es/v1/client_test.go
@@ -54,3 +54,20 @@ func TestExcludeNodeFromAllocation(t *testing.T) {
 		t.Errorf("error should not be raised: %s", err)
 	}
 }
+
+func TestShutdown(t *testing.T) {
+	defer gock.Off()
+
+	client := &Client{
+		client:          nil,
+		clusterEndpoint: testClusterEndpoint,
+	}
+
+	gock.New(testClusterEndpoint).Post("/_cluster/nodes/ip-10-0-1-23.ap-northeast-1.compute.internal/_shutdown").Reply(200)
+
+	nodeName := "ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	if err := client.Shutdown(nodeName); err != nil {
+		t.Errorf("error should not be raised: %s", err)
+	}
+}

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -161,3 +161,8 @@ func (c *Client) ListNodes() ([]string, error) {
 
 	return nodes, nil
 }
+
+// Shutdown does nothing, because Elasticsearch 2.x does not have shutdown API
+func (c *Client) Shutdown(nodeName string) error {
+	return nil
+}

--- a/es/v2/client_test.go
+++ b/es/v2/client_test.go
@@ -54,3 +54,33 @@ func TestExcludeNodeFromAllocation(t *testing.T) {
 		t.Errorf("error should not be raised: %s", err)
 	}
 }
+
+func TestListShardsOnNode(t *testing.T) {
+	defer gock.Off()
+
+	client := &Client{
+		client:          nil,
+		clusterEndpoint: testClusterEndpoint,
+	}
+
+	gock.New(testClusterEndpoint).Get("/_cat/shards").Reply(200).BodyString(`wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal
+wiki1 1 p STARTED 3013 29.6mb 192.168.56.30 Frankie Raye
+wiki1 2 p STARTED 3973 38.1mb 192.168.56.20 Commander Kraken`)
+
+	nodeName := "ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	shards, err := client.ListShardsOnNode(nodeName)
+	if err != nil {
+		t.Errorf("error should not be raised: %s", err)
+	}
+
+	if len(shards) != 1 {
+		t.Errorf("number of shards does not match. expected: 1, got: %d", len(shards))
+	}
+
+	expected := "wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	if shards[0] != expected {
+		t.Errorf("shard does not match. expected: %q, got: %q", expected, shards[0])
+	}
+}

--- a/es/v2/client_test.go
+++ b/es/v2/client_test.go
@@ -37,3 +37,20 @@ func TestEnableReallocation(t *testing.T) {
 		t.Errorf("error should not be raised: %s", err)
 	}
 }
+
+func TestExcludeNodeFromAllocation(t *testing.T) {
+	defer gock.Off()
+
+	client := &Client{
+		client:          nil,
+		clusterEndpoint: testClusterEndpoint,
+	}
+
+	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.exclude._name":"ip-10-0-1-23.ap-northeast-1.compute.internal"}}`).Reply(200)
+
+	nodeName := "ip-10-0-1-23.ap-northeast-1.compute.internal"
+
+	if err := client.ExcludeNodeFromAllocation(nodeName); err != nil {
+		t.Errorf("error should not be raised: %s", err)
+	}
+}


### PR DESCRIPTION
## WHY

Removing node from Elasticsearch cluster requires the steps below:

- remove instance from ELB
- wait for connection draining
- ✅ exclude the node from shard allocation group
- ✅ wait for that shards escape from the node
- ✅ (Es 1.x) shutdown the node
- detach instance from ASG

## WHAT

Do Elasticsearch-related steps