### PR TITLE
Use common HTTP client

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/dtan4/esnctl/aws"
@@ -43,7 +44,9 @@ func doAdd(cmd *cobra.Command, args []string) error {
 		return errors.New("number to add instances must be greater than 0")
 	}
 
-	client, err := es.New(addOpts.clusterURL)
+	httpClient := &http.Client{}
+
+	client, err := es.New(addOpts.clusterURL, httpClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Elasitcsearch API client")
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/dtan4/esnctl/es"
 	"github.com/pkg/errors"
@@ -26,7 +27,9 @@ func doList(cmd *cobra.Command, args []string) error {
 		return errors.New("Elasticsearch cluster URL must be specified")
 	}
 
-	client, err := es.New(listOpts.clusterURL)
+	httpClient := &http.Client{}
+
+	client, err := es.New(listOpts.clusterURL, httpClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Elasitcsearch API client")
 	}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/dtan4/esnctl/aws"
@@ -41,7 +42,9 @@ func doRemove(cmd *cobra.Command, args []string) error {
 		return errors.New("Elasticsearch Node name must be specified")
 	}
 
-	client, err := es.New(removeOpts.clusterURL)
+	httpClient := &http.Client{}
+
+	client, err := es.New(removeOpts.clusterURL, httpClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to create Elasitcsearch API client")
 	}

--- a/es/es_test.go
+++ b/es/es_test.go
@@ -1,6 +1,7 @@
 package es
 
 import (
+	"net/http"
 	"testing"
 
 	"gopkg.in/h2non/gock.v1"
@@ -51,7 +52,7 @@ func TestDetectVersion(t *testing.T) {
 	for _, tc := range testcases {
 		gock.New(tc.clusterURL).Get("/").Reply(200).BodyString(tc.body)
 
-		got, err := DetectVersion(tc.clusterURL)
+		got, err := DetectVersion(tc.clusterURL, &http.Client{})
 		if err != nil {
 			t.Errorf("error should not be raised: %s", err)
 		}

--- a/es/v1/client.go
+++ b/es/v1/client.go
@@ -157,7 +157,7 @@ func (c *Client) ListNodes() ([]string, error) {
 	return nodes, nil
 }
 
-// ListShards returns the list of shards on the given node
+// ListShardsOnNode returns the list of shards on the given node
 func (c *Client) ListShardsOnNode(nodeName string) ([]string, error) {
 	endpoint := c.clusterEndpoint + "/_cat/shards/"
 

--- a/es/v1/client_test.go
+++ b/es/v1/client_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"net/http"
 	"testing"
 
 	"gopkg.in/h2non/gock.v1"
@@ -14,6 +15,7 @@ func TestDisableReallocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.enable":"none"}}`).Reply(200)
@@ -29,6 +31,7 @@ func TestEnableReallocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.enable":"all"}}`).Reply(200)
@@ -44,6 +47,7 @@ func TestExcludeNodeFromAllocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.exclude._name":"ip-10-0-1-23.ap-northeast-1.compute.internal"}}`).Reply(200)
@@ -61,6 +65,7 @@ func TestListShardsOnNode(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Get("/_cat/shards").Reply(200).BodyString(`wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal
@@ -91,6 +96,7 @@ func TestShutdown(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Post("/_cluster/nodes/ip-10-0-1-23.ap-northeast-1.compute.internal/_shutdown").Reply(200)

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -157,7 +157,7 @@ func (c *Client) ListNodes() ([]string, error) {
 	return nodes, nil
 }
 
-// ListShards returns the list of shards on the given node
+// ListShardsOnNode returns the list of shards on the given node
 func (c *Client) ListShardsOnNode(nodeName string) ([]string, error) {
 	endpoint := c.clusterEndpoint + "/_cat/shards/"
 

--- a/es/v2/client.go
+++ b/es/v2/client.go
@@ -15,10 +15,11 @@ import (
 type Client struct {
 	client          *elastic.Client
 	clusterEndpoint string
+	httpClient      *http.Client
 }
 
 // NewClient creates new Client object
-func NewClient(clusterURL string) (*Client, error) {
+func NewClient(clusterURL string, httpClient *http.Client) (*Client, error) {
 	u, err := url.Parse(clusterURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse cluster URL")
@@ -46,6 +47,7 @@ func NewClient(clusterURL string) (*Client, error) {
 	return &Client{
 		client:          client,
 		clusterEndpoint: clusterEndpoint,
+		httpClient:      httpClient,
 	}, nil
 }
 
@@ -53,7 +55,6 @@ func NewClient(clusterURL string) (*Client, error) {
 // Modifies cluster.routing.allocation.enable to "none"
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) DisableReallocation() error {
-	httpClient := &http.Client{}
 	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"none"}}`))
@@ -62,7 +63,7 @@ func (c *Client) DisableReallocation() error {
 	}
 	defer req.Body.Close()
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to execute DisableReallocation request")
 	}
@@ -84,7 +85,6 @@ func (c *Client) DisableReallocation() error {
 // Modifies cluster.routing.allocation.enable to "all"
 // https://www.elastic.co/guide/en/elasticsearch/reference/1.5/cluster-update-settings.html
 func (c *Client) EnableReallocation() error {
-	httpClient := &http.Client{}
 	endpoint := c.clusterEndpoint + "/_cluster/settings"
 
 	req, err := http.NewRequest("PUT", endpoint, strings.NewReader(`{"transient":{"cluster.routing.allocation.enable":"all"}}`))
@@ -93,7 +93,7 @@ func (c *Client) EnableReallocation() error {
 	}
 	defer req.Body.Close()
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to execute EnableReallocation request")
 	}
@@ -114,7 +114,6 @@ func (c *Client) EnableReallocation() error {
 // ExcludeNodeFromAllocation excludes the given node from shard allocation group
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/allocation-filtering.html
 func (c *Client) ExcludeNodeFromAllocation(nodeName string) error {
-	httpClient := &http.Client{}
 	endpoint := c.clusterEndpoint + "/_cluster/settings"
 	reqBody := fmt.Sprintf(`{"transient":{"cluster.routing.allocation.exclude._name":"%s"}}`, nodeName)
 
@@ -124,7 +123,7 @@ func (c *Client) ExcludeNodeFromAllocation(nodeName string) error {
 	}
 	defer req.Body.Close()
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to execute ExcludeNodeFromAllocation request")
 	}
@@ -160,7 +159,6 @@ func (c *Client) ListNodes() ([]string, error) {
 
 // ListShards returns the list of shards on the given node
 func (c *Client) ListShardsOnNode(nodeName string) ([]string, error) {
-	httpClient := &http.Client{}
 	endpoint := c.clusterEndpoint + "/_cat/shards/"
 
 	req, err := http.NewRequest("GET", endpoint, nil)
@@ -168,7 +166,7 @@ func (c *Client) ListShardsOnNode(nodeName string) ([]string, error) {
 		return []string{}, errors.Wrap(err, "failed to make cat-shards request")
 	}
 
-	resp, err := httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return []string{}, errors.Wrap(err, "failed to execute Shutdown request")
 	}

--- a/es/v2/client_test.go
+++ b/es/v2/client_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"net/http"
 	"testing"
 
 	"gopkg.in/h2non/gock.v1"
@@ -14,6 +15,7 @@ func TestDisableReallocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.enable":"none"}}`).Reply(200)
@@ -29,6 +31,7 @@ func TestEnableReallocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.enable":"all"}}`).Reply(200)
@@ -44,6 +47,7 @@ func TestExcludeNodeFromAllocation(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Put("/_cluster/settings").BodyString(`{"transient":{"cluster.routing.allocation.exclude._name":"ip-10-0-1-23.ap-northeast-1.compute.internal"}}`).Reply(200)
@@ -61,6 +65,7 @@ func TestListShardsOnNode(t *testing.T) {
 	client := &Client{
 		client:          nil,
 		clusterEndpoint: testClusterEndpoint,
+		httpClient:      &http.Client{},
 	}
 
 	gock.New(testClusterEndpoint).Get("/_cat/shards").Reply(200).BodyString(`wiki1 0 p STARTED 3014 31.1mb 192.168.56.10 ip-10-0-1-23.ap-northeast-1.compute.internal


### PR DESCRIPTION
## WHY

Now esnctl creates new HTTP clients per each Elasticsearch API request. It would consume more memory.

## WHAT

Create a common HTTP client at first, then use them at all API calls.